### PR TITLE
Add working vertical slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # FontGen AI Studio Starter
 
 This repo contains minimal boilerplate files for every runtime referenced in the universal setup script.
+
+## Running the vertical slice
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the backend:
+   ```bash
+   python backend.py
+   ```
+3. Open `index.html` in your browser and try generating fonts. Free users are limited to three generations unless `api_key: "premium"` is provided in the request payload.

--- a/backend.py
+++ b/backend.py
@@ -1,4 +1,21 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request, send_file
+from io import BytesIO
+from PIL import Image, ImageDraw, ImageFont
+import base64
+import uuid
+
+free_limit = 3
+usage = {}
+fonts = {}
+
+def create_font_image(prompt: str) -> bytes:
+    img = Image.new("RGB", (400, 200), color="white")
+    d = ImageDraw.Draw(img)
+    text = f"Font for: {prompt}"
+    d.text((10, 90), text, fill="black")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
 
 app = Flask(__name__)
 
@@ -6,5 +23,50 @@ app = Flask(__name__)
 def home():
     return jsonify(message="FontGen backend is alive! 🚀")
 
+
+@app.route("/generate", methods=["POST"])
+def generate_font():
+    data = request.get_json() or {}
+    prompt = data.get("prompt")
+    api_key = data.get("api_key", "")
+    user = api_key or request.remote_addr
+
+    if not prompt:
+        return jsonify(error="Prompt required"), 400
+
+    count = usage.get(user, 0)
+    if api_key != "premium" and count >= free_limit:
+        return jsonify(error="Free limit reached. Upgrade to premium."), 403
+
+    font_data = create_font_image(prompt)
+    font_id = str(uuid.uuid4())
+    fonts[font_id] = font_data
+    usage[user] = count + 1
+
+    preview_b64 = base64.b64encode(font_data).decode("utf-8")
+    remaining = None if api_key == "premium" else max(0, free_limit - usage[user])
+    return jsonify(font_id=font_id, preview=preview_b64, remaining=remaining)
+
+
+@app.route("/download/<font_id>")
+def download_font(font_id):
+    font = fonts.get(font_id)
+    if not font:
+        return jsonify(error="Font not found"), 404
+    return send_file(
+        BytesIO(font),
+        mimetype="image/png",
+        as_attachment=True,
+        download_name=f"{font_id}.png",
+    )
+
+
+@app.route("/preview/<font_id>")
+def preview_font(font_id):
+    font = fonts.get(font_id)
+    if not font:
+        return jsonify(error="Font not found"), 404
+    return send_file(BytesIO(font), mimetype="image/png")
+
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+    app.run(host="0.0.0.0", port=5050)

--- a/index.html
+++ b/index.html
@@ -3,8 +3,39 @@
 <head>
   <meta charset="UTF-8">
   <title>FontGen AI Studio</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; }
+    #preview img { max-width: 400px; margin-top: 20px; }
+  </style>
 </head>
 <body>
-  <h1>🚀 FontGen Frontend is Alive</h1>
+  <h1>FontGen AI Studio</h1>
+  <input id="prompt" placeholder="Describe your font" size="40" />
+  <button id="generate">Generate</button>
+  <div id="message"></div>
+  <div id="preview"></div>
+  <a id="download" style="display:none" href="#">Download</a>
+  <script>
+    const apiKey = localStorage.getItem('api_key') || '';
+    async function generate(){
+      const prompt = document.getElementById('prompt').value;
+      const res = await fetch('/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt, api_key: apiKey })
+      });
+      const data = await res.json();
+      if(!res.ok){
+        document.getElementById('message').textContent = data.error;
+        return;
+      }
+      document.getElementById('message').textContent = data.remaining === null ? 'Premium user' : `Remaining free uses: ${data.remaining}`;
+      document.getElementById('preview').innerHTML = `<img src="data:image/png;base64,${data.preview}" />`;
+      const download = document.getElementById('download');
+      download.href = '/download/' + data.font_id;
+      download.style.display = 'inline';
+    }
+    document.getElementById('generate').addEventListener('click', generate);
+  </script>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 openai
+pillow


### PR DESCRIPTION
## Summary
- show a basic Flask backend with /generate, /download, and /preview routes
- add simple frontend page to interact with the backend
- document how to run the demo and add Pillow requirement
- tweak backend port to avoid conflicts

## Testing
- `pip install pillow`
- `python backend.py` *(fails: address in use)*
- `python backend.py` *(runs on port 5050)*
- `curl -X POST -H "Content-Type: application/json" -d '{"prompt":"test"}' http://localhost:5050/generate | head -c 200`


------
https://chatgpt.com/codex/tasks/task_e_6856a44fc2088328afc3a7a9ff03d56a