### PR TITLE
Add download-all feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This repo contains minimal boilerplate files for every runtime referenced in the
    ```bash
    python backend.py
    ```
-3. Open `index.html` in your browser and try generating fonts. Free users are limited to three generations unless `api_key: "premium"` is provided in the request payload.
+3. Open `index.html` in your browser and try generating fonts. Free users are limited to three generations unless `api_key: "premium"` is provided in the request payload. You can download individual fonts or use the new **Download All** link to grab a zip of every font created in your session.

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <div id="message"></div>
   <div id="preview"></div>
   <a id="download" style="display:none" href="#">Download</a>
+  <a id="download-all" style="display:none" href="#">Download All</a>
   <script>
     const apiKey = localStorage.getItem('api_key') || '';
     async function generate(){
@@ -34,6 +35,9 @@
       const download = document.getElementById('download');
       download.href = '/download/' + data.font_id;
       download.style.display = 'inline';
+      const downloadAll = document.getElementById('download-all');
+      downloadAll.href = '/download_all' + (apiKey ? `?api_key=${apiKey}` : '');
+      downloadAll.style.display = 'inline';
     }
     document.getElementById('generate').addEventListener('click', generate);
   </script>


### PR DESCRIPTION
## Summary
- allow bulk font downloads by session via `/download_all`
- show 'Download All' link in UI
- mention new download feature in docs

## Testing
- `python -m py_compile backend.py`
- `python - <<'PY'
import backend
app = backend.app
client = app.test_client()
resp = client.post('/generate', json={'prompt': 'test font', 'api_key': 'premium'})
print('generate status', resp.status_code)
fid = resp.get_json()['font_id']
resp = client.get('/download_all?api_key=premium')
print('download_all status', resp.status_code, 'length', len(resp.data))
PY


------
https://chatgpt.com/codex/tasks/task_e_6856aa32ca3883289d4a8c8627a87d12