### PR TITLE
Add share endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ This repo contains minimal boilerplate files for every runtime referenced in the
    python backend.py
    ```
 3. Open `index.html` in your browser and try generating fonts. Free users are limited to three generations unless `api_key: "premium"` is provided in the request payload.
+
+## Sharing previews
+
+To share a generated font preview with others, request `/share/<font_id>` from the backend. It returns a JSON payload containing a public URL that anyone can open to view the preview image in the browser.

--- a/backend.py
+++ b/backend.py
@@ -68,5 +68,16 @@ def preview_font(font_id):
         return jsonify(error="Font not found"), 404
     return send_file(BytesIO(font), mimetype="image/png")
 
+
+# New route to obtain a public share URL for a generated font
+@app.route("/share/<font_id>")
+def share_font(font_id):
+    """Return a sharable URL that opens the preview in the browser."""
+    if font_id not in fonts:
+        return jsonify(error="Font not found"), 404
+    # Compose full URL to the preview endpoint
+    url = request.host_url.rstrip("/") + f"/preview/{font_id}"
+    return jsonify(url=url)
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5050)


### PR DESCRIPTION
## Summary
- add `/share/<font_id>` API endpoint to give public preview URL
- document sharing a font in README

## Testing
- `python -m py_compile backend.py`
- `python - <<'PY'
import backend
font_id='test'
backend.fonts[font_id]=b'data'
from backend import app
with app.test_client() as c:
    resp=c.get('/share/'+font_id)
    print('status', resp.status_code)
    print(resp.get_json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6856aa2ca7508328ac6262689beecac9